### PR TITLE
Added the synthesis template

### DIFF
--- a/synthesis_template/CMakeLists.txt
+++ b/synthesis_template/CMakeLists.txt
@@ -23,7 +23,8 @@ project(nand_gate)
 set(SC_TOP "nand_gate")
 
 # Name of the toplevel SystemVerilog component
-# (This should be identical in most cases)
+# (This should only differ from SC_TOP if the SystemC module has the name of a
+# SystemVerilog keyword)
 set(SV_TOP ${SC_TOP})
 # *****************************************************************************
 

--- a/synthesis_template/CMakeLists.txt
+++ b/synthesis_template/CMakeLists.txt
@@ -1,0 +1,96 @@
+#******************************************************************************
+# Copyright (c) 2020, Intel Corporation. All rights reserved.
+# 
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception.
+# 
+# *****************************************************************************
+
+cmake_minimum_required(VERSION 3.12)
+
+enable_testing()
+
+if(NOT DEFINED ENV{ICSC_HOME})
+  message("ICSC_HOME is not defined!")
+  return()
+endif()
+
+# *****************************************************************************
+# Change these variables to fit your project
+
+project(nand_gate)
+
+# Name of the toplevel SystemC component
+set(SC_TOP "nand_gate")
+
+# Name of the toplevel SystemVerilog component
+# (This should be identical in most cases)
+set(SV_TOP ${SC_TOP})
+# *****************************************************************************
+
+## SVC package contains ScTool and SystemC libraries
+find_package(SVC REQUIRED)
+
+# C++ standard must be the same as in ScTool, $(SystemC_CXX_STANDARD) contains 17
+set(CMAKE_CXX_STANDARD 17)
+
+#include_directories($ENV{ICSC_HOME}/include)
+
+
+# All synthesizable source files must be listed here (not in libraries)
+add_executable(${SC_TOP}
+    testbench.cpp
+)
+
+# Add compilation options
+# target_compile_definitions(mydesign PUBLIC -DMYOPTION)
+# target_compile_options(mydesign PUBLIC -Wall)
+
+# Add optional library, do not add SystemC library (it added by svc_target)
+#target_link_libraries(mydesign sometestbenchlibrary)
+
+# svc_target will create @mydesign_sctool executable that runs code generation 
+# and @mydesign that runs general SystemC simulation
+# ELAB_TOP parameter accepts hierarchical name of DUT  
+# (that is SystemC name, returned by sc_object::name() method)
+svc_target(${SC_TOP} INIT_LOCAL_VARS ELAB_TOP tb.dut_inst)
+
+add_custom_command(OUTPUT sv_out/${SC_TOP}.sv
+    COMMAND ./${SC_TOP}_sctool
+
+    COMMENT "Starting compilation to SystemVerilog"
+)
+
+add_custom_target(synthesis
+    COMMAND yosys -p 'read_verilog -sv sv_out/${SC_TOP}.sv\; proc\; hierarchy -top ${SV_TOP}\; write_json ${SV_TOP}.json'
+
+    BYPRODUCTS ${SV_TOP}.json
+    DEPENDS sv_out/${SC_TOP}.sv
+
+    COMMENT "Starting generic synthesis"
+)
+
+add_custom_target(synthesis_ice40
+    COMMAND yosys -p 'read_verilog -sv sv_out/${SC_TOP}.sv\; hierarchy -top ${SV_TOP}\; synth_ice40 -dsp -spram -top ${SV_TOP}\; write_json ${SV_TOP}.json'
+
+    BYPRODUCTS ${SV_TOP}.json
+    DEPENDS sv_out/${SC_TOP}.sv
+
+    COMMENT "Starting ice40 synthesis"
+)
+
+add_custom_target(visualize
+    COMMAND sed -i -e 's/inout/output/g' ${SV_TOP}.json
+    COMMAND netlistsvg ${SV_TOP}.json -o ${SV_TOP}.svg
+    COMMAND svgo ${SV_TOP}.svg
+    COMMAND rsvg-convert -f pdf -o ${SV_TOP}.pdf ${SV_TOP}.svg
+
+    BYPRODUCTS ${SV_TOP}.svg
+    BYPRODUCTS ${SV_TOP}.pdf
+
+    DEPENDS ${SV_TOP}.json
+
+    COMMENT "Generating svg and pdf visualization"
+)
+
+# add_dependencies(visualize synthesis)
+add_dependencies(synthesis ${SC_TOP}_sctool)

--- a/synthesis_template/nand_gate.h
+++ b/synthesis_template/nand_gate.h
@@ -1,0 +1,21 @@
+#ifndef NAND_GATE_H
+#define NAND_GATE_H
+
+#include <systemc.h>
+
+SC_MODULE(nand_gate){
+    sc_in<bool> A;
+    sc_in<bool> B;
+    sc_out<bool> Z;
+
+    void do_nand() {
+        Z.write(!(A.read() && B.read()));
+    }
+
+    SC_CTOR(nand_gate): A("A"), B("B"), Z("Z") {
+        SC_METHOD(do_nand);
+        sensitive << A << B;
+    }
+};
+
+#endif

--- a/synthesis_template/testbench.cpp
+++ b/synthesis_template/testbench.cpp
@@ -1,0 +1,37 @@
+/******************************************************************************
+ * Copyright (c) 2020, Intel Corporation. All rights reserved.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception.
+ * 
+ *****************************************************************************/
+
+// Design template
+
+#include <systemc.h>
+#include "nand_gate.h"
+ 
+// ICSC requires DUT top should be instantiated inside wrapper (typically TB) 
+// and all DUT ports are bound.
+struct Tb : sc_module 
+{
+    sc_signal<bool> a{"a"};
+    
+    sc_signal<bool> b{"b"};
+    sc_signal<bool> z{"z"};
+ 
+    nand_gate dut_inst{"dut_inst"};
+
+    SC_CTOR(Tb) 
+    {
+        dut_inst.A(a);
+        dut_inst.B(b);
+        dut_inst.Z(z);
+    }
+};
+ 
+int sc_main (int argc, char **argv)
+{
+     Tb tb("tb");
+     sc_start();
+     return 0;
+}


### PR DESCRIPTION
This template allows the synthesis of basic SystemC code. It adds these targets:

- synthesis: generic synthesis with Yosys
- synthesis_ice40: synthesis for the ice40 FPGA family
- visualize: generate a netlist as pdf/svg for previous synthesis